### PR TITLE
Remove Lebara UK

### DIFF
--- a/serviceproviders.xml
+++ b/serviceproviders.xml
@@ -5166,22 +5166,6 @@ conceived.
 		</gsm>
 	</provider>
 	<provider>
-		<name>Lebara UK</name>
-		<gsm>
-			<network-id mcc="234" mnc="15"/>
-			<apn value="uk.lebara.mobi">
-				<plan type="prepaid"/>
-				<usage type="internet"/>
-				<name>Lebara UK</name>
-				<username>wap</username>
-				<password>wap</password>
-				<mmsc>http://mms.lebara.co.uk/servlets/mms</mmsc>
-				<mmsproxy>212.183.137.12:8799</mmsproxy>
-				<mmsattachmentsize>306200</mmsattachmentsize>
-			</apn>
-		</gsm>
-	</provider>
-	<provider>
 		<name>EE</name>
 		<gsm>
 			<network-id mcc="234" mnc="30"/>


### PR DESCRIPTION
Voda UK stopped working when Lebara UK was included.
Tested on a user camera to remove Lebara UK and then they could connect again.
Suspecting that it's used for Voda UK due to same mcc and mnc.
We don't support Lebara officially and can't see anyone trying to use it.
We do support Vodafone UK: https://support.veo.co/hc/en-us/articles/5408222668049-Data-providers-and-SIM-cards-for-the-Veo-Cam